### PR TITLE
Change Django version to 2.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==2.1.1
+Django==2.1.2
 pytz==2018.5


### PR DESCRIPTION
The prior version of Django (2.1.2) has a security vulnerability and as a result GitHut kept warning about that.